### PR TITLE
Check if sqlite is installed before running the migration

### DIFF
--- a/.idea/dev070.iml
+++ b/.idea/dev070.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="PYTHON_MODULE" version="4">
-  <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="jdk" jdkName="Python 2.7.10 (/System/Library/Frameworks/Python.framework/Versions/2.7/bin/python2.7)" jdkType="Python SDK" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/lib/migration/mongo.py
+++ b/lib/migration/mongo.py
@@ -43,11 +43,18 @@ class Migrate(object):
         :return: CSV files into csv_exports directory
         """
         self.migration_read = '.read ' + self.migration_script
-        subprocess.check_call([
-            'sqlite3',
-            self.db,
-            self.migration_read
-        ])
+        try:
+            subprocess.check_call([
+                'sqlite3',
+                self.db,
+                self.migration_read
+            ])
+        except OSError as e:
+            if e.errno == os.errno.ENOENT:
+                 print('[Error] sqlite binary not found: install SQLite',e)
+                 raise
+            else:
+                 raise
 
     def do_csv_to_mongo(self, ):
         """ read the csv files and populate the vFeed MongoDB


### PR DESCRIPTION
Go this error once while trying to migrate to MongoDB: 

> [+] Mongo service is up. Starting migrating ....
> Traceback (most recent call last):
>   File "./vfeedcli.py", line 62, in <module>
>     Migrate()
>   File "/home/alex/vfeed/vFeed-0.7.0.1/lib/migration/mongo.py", line 29, in __init__
>     self.do_sqlite_to_csv()
>   File "/home/alex/vfeed/vFeed-0.7.0.1/lib/migration/mongo.py", line 51, in do_sqlite_to_csv
>     self.migration_read
>   File "/usr/lib/python2.7/subprocess.py", line 536, in check_call
>     retcode = call(*popenargs, **kwargs)
>   File "/usr/lib/python2.7/subprocess.py", line 523, in call
>     return Popen(*popenargs, **kwargs).wait()
>   File "/usr/lib/python2.7/subprocess.py", line 711, in __init__
>     errread, errwrite)
>   File "/usr/lib/python2.7/subprocess.py", line 1343, in _execute_child
>     raise child_exception
> OSError: [Errno 2] No such file or directory

Which is not explicit.
So I added a try/except to add this line in that specific case:

> [Error] sqlite binary not found: install SQLite [Errno 2] No such file or directory
